### PR TITLE
Fix macOS instructions copy: rename to Preferences

### DIFF
--- a/Shared/Views/InstructionsView.swift
+++ b/Shared/Views/InstructionsView.swift
@@ -45,7 +45,7 @@ struct InstructionsView: View {
                         Text("Select ") +
                         Text("Extensions").bold() +
                         Text(" in ") +
-                        Text("Settings").bold()
+                        Text("Preferences").bold()
                 )
                 Instruction(
                     imageName: "Checkbox",


### PR DESCRIPTION
Fixes #9