### PR TITLE
bloomberg.com

### DIFF
--- a/data/site-specific.txt
+++ b/data/site-specific.txt
@@ -5,6 +5,7 @@ nytimes.com##.gdpr
 cnbc.com###cnbcgdpr
 paypal.com###gdprCookieBanner
 fedex.com##.fxg-cookie-consent
+bloomberg.com##div[id*="sp_message_container_"]
 
 ! ----- Hidden newsletter signup selectors -----
 


### PR DESCRIPTION
Looks like this isn't quite complete: the page also loads with `class="sp-message-open"` on the `<html>` element, and this class prevents the page from scrolling. Ideally, this project should have some way of saying "remove this specific class from this specific page element".