### PR TITLE
Block CCPA cookie banner on PayPal

### DIFF
--- a/data/site-specific.txt
+++ b/data/site-specific.txt
@@ -17,6 +17,7 @@
 nytimes.com##.gdpr
 cnbc.com###cnbcgdpr
 paypal.com###gdprCookieBanner
+paypal.com###ccpaCookieBanner
 fedex.com##.fxg-cookie-consent
 picnic.app##.cookies
 spotify.com###onetrust-banner-sdk


### PR DESCRIPTION
<img width="961" alt="Screen Shot 2021-05-19 at 20 35 03" src="https://user-images.githubusercontent.com/108518/118901610-b6dcad00-b8e1-11eb-8d08-b9197974949d.png">

PayPal shows this if you haven't accepted their marketing cookies, even if you've gone to their cookie setting page and customized your settings. 😭 