### PR TITLE
Update activation copy for iOS 15

### DIFF
--- a/Shared/Views/InstructionsView.swift
+++ b/Shared/Views/InstructionsView.swift
@@ -69,7 +69,11 @@ struct InstructionsView: View {
                         Text("Tap ") +
                         Text("Safari").bold() +
                         Text(", then ") +
-                        Text("Content Blockers").bold()
+                        Text(
+                            ProcessInfo().operatingSystemVersion.majorVersion >= 15
+                                ? "Extensions"
+                                : "Content Blockers"
+                        ).bold()
                 )
                 Instruction(
                     imageName: "Toggle",


### PR DESCRIPTION
Apple has renamed the setting name in iOS 15 as they have expanded the capabilities of Safari to allow any kind of extension. 

<img width="890" alt="Skärmavbild 2021-06-18 kl  17 12 26" src="https://user-images.githubusercontent.com/378279/122582504-8743d080-d058-11eb-9fb4-1a30aecdde0c.png">
